### PR TITLE
Basic Looting Enchantment implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For example: A single Zombie Spawner spawns one Zombie every 40 seconds. Stackin
 - [x] Allow toggling XP Drops for Mobs
 - [ ] Spawner Shop with configurable prices
 - [ ] Set Mob Experience drops correctly
-- [ ] Implement Looting Enchantment
+- [x] Implement Looting Enchantment
 - [ ] Autostack spawners when placed near another spawner of the same type
 - [x] Allow changing of the entity scale within the Spawner
 - [ ] Toggle spawning one every 20 seconds, or two every 40 seconds 

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,7 @@
 ---
 name: BurgerSpawners
 main: Heisenburger69\BurgerSpawners\Main
-version: 0.0.3
+version: 0.0.4
 api: 3.0.0
 author: Heisenburger69
 website: https://github.com/Heisenburger69

--- a/src/Heisenburger69/BurgerSpawners/Entities/Bee.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Bee.php
@@ -16,6 +16,7 @@ class Bee extends Living
 
     public $width = 0.6;
     public $height = 0.6;
+    public $lootingL;
 
     public function getName(): string
     {

--- a/src/Heisenburger69/BurgerSpawners/Entities/Bee.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Bee.php
@@ -6,6 +6,8 @@ use Heisenburger69\BurgerSpawners\Pocketmine\AddActorPacket;
 
 use pocketmine\entity\Living;
 use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class Bee extends Living
 {

--- a/src/Heisenburger69/BurgerSpawners/Entities/Bee.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Bee.php
@@ -16,7 +16,6 @@ class Bee extends Living
 
     public $width = 0.6;
     public $height = 0.6;
-    public $lootingL;
 
     public function getName(): string
     {

--- a/src/Heisenburger69/BurgerSpawners/Entities/Blaze.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Blaze.php
@@ -21,6 +21,7 @@ class Blaze extends Monster
     }
 
     public function getDrops(): array{
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Blaze.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Blaze.php
@@ -4,6 +4,9 @@ namespace Heisenburger69\BurgerSpawners\Entities;
 
 use pocketmine\entity\Monster;
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class Blaze extends Monster
 {
@@ -18,7 +21,19 @@ class Blaze extends Monster
     }
 
     public function getDrops(): array{
-        return [Item::get(Item::BLAZE_ROD, 0, mt_rand(0, 1))];
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
+        return [Item::get(Item::BLAZE_ROD, 0, mt_rand(0, 1 * $lootingL))];
     }
 
 }

--- a/src/Heisenburger69/BurgerSpawners/Entities/Blaze.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Blaze.php
@@ -15,7 +15,6 @@ class Blaze extends Monster
 
     public $width = 0.6;
     public $height = 1.8;
-    public $lootingL;
 
     public function getName(): string{
         return "Blaze";
@@ -26,6 +25,8 @@ class Blaze extends Monster
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                 
+/** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Blaze.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Blaze.php
@@ -15,6 +15,7 @@ class Blaze extends Monster
 
     public $width = 0.6;
     public $height = 1.8;
+    public $lootingL;
 
     public function getName(): string{
         return "Blaze";

--- a/src/Heisenburger69/BurgerSpawners/Entities/Blaze.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Blaze.php
@@ -27,7 +27,7 @@ class Blaze extends Monster
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
                  
-/** @var Enchantment $looting */
+
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/CaveSpider.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/CaveSpider.php
@@ -30,7 +30,7 @@ class CaveSpider extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+              
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/CaveSpider.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/CaveSpider.php
@@ -25,6 +25,7 @@ class CaveSpider extends Monster {
     }
 
     public function getDrops(): array{
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/CaveSpider.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/CaveSpider.php
@@ -19,6 +19,7 @@ class CaveSpider extends Monster {
     /** @var int */
     public $length = 1;
     public $height = 0.5;
+    public $lootingL;
 
     public function getName(): string{
         return "Cave Spider";

--- a/src/Heisenburger69/BurgerSpawners/Entities/CaveSpider.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/CaveSpider.php
@@ -19,7 +19,6 @@ class CaveSpider extends Monster {
     /** @var int */
     public $length = 1;
     public $height = 0.5;
-    public $lootingL;
 
     public function getName(): string{
         return "Cave Spider";
@@ -30,6 +29,7 @@ class CaveSpider extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/CaveSpider.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/CaveSpider.php
@@ -8,6 +8,8 @@ use pocketmine\entity\Monster;
 use pocketmine\event\entity\EntityDamageByEntityEvent;
 use pocketmine\item\Item;
 use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+
 
 class CaveSpider extends Monster {
 
@@ -23,8 +25,20 @@ class CaveSpider extends Monster {
     }
 
     public function getDrops(): array{
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
         $drops = [
-            Item::get(Item::STRING, 0, mt_rand(0, 2)),
+            Item::get(Item::STRING, 0, mt_rand(0, 2 * $lootingL)),
         ];
 
         if(mt_rand(1, 3) == 2){
@@ -32,7 +46,7 @@ class CaveSpider extends Monster {
             if($lastDamage instanceof EntityDamageByEntityEvent){
                 $ent = $lastDamage->getDamager();
                 if($ent instanceof Player){
-                    $drops[] = Item::get(Item::SPIDER_EYE, 0, 1);
+                    $drops[] = Item::get(Item::SPIDER_EYE, 0, 1 * $lootingL);
                 }
             }
         }

--- a/src/Heisenburger69/BurgerSpawners/Entities/Chicken.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Chicken.php
@@ -23,6 +23,7 @@ class Chicken extends Animal {
     }
 
     public function getDrops(): array{
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Chicken.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Chicken.php
@@ -16,6 +16,7 @@ class Chicken extends Animal {
     /** @var float */
     public $length = 0.6;
     public $height = 0;
+    public $lootingL;
 
     public function getName(): string{
         return "Chicken";

--- a/src/Heisenburger69/BurgerSpawners/Entities/Chicken.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Chicken.php
@@ -16,7 +16,7 @@ class Chicken extends Animal {
     /** @var float */
     public $length = 0.6;
     public $height = 0;
-    public $lootingL;
+
 
     public function getName(): string{
         return "Chicken";
@@ -27,6 +27,7 @@ class Chicken extends Animal {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+               /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Chicken.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Chicken.php
@@ -4,6 +4,9 @@ namespace Heisenburger69\BurgerSpawners\Entities;
 
 use pocketmine\entity\Animal;
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class Chicken extends Animal {
 
@@ -19,9 +22,21 @@ class Chicken extends Animal {
     }
 
     public function getDrops(): array{
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
         $drops = [
-            Item::get(Item::FEATHER, 0, mt_rand(0, 2)),
-            Item::get(Item::RAW_CHICKEN, 0, 1),
+            Item::get(Item::FEATHER, 0, mt_rand(0, 2 * $lootingL)),
+            Item::get(Item::RAW_CHICKEN, 0, 1 * $lootingL),
         ];
 
         return $drops;

--- a/src/Heisenburger69/BurgerSpawners/Entities/Chicken.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Chicken.php
@@ -28,7 +28,7 @@ class Chicken extends Animal {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-               /** @var Enchantment $looting */
+              
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Cow.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Cow.php
@@ -16,6 +16,7 @@ class Cow extends Animal {
 
     public $width = 0.9;
     public $height = 1.3;
+    public $lootingL;
 
     public function getName(): string{
         return "Cow";

--- a/src/Heisenburger69/BurgerSpawners/Entities/Cow.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Cow.php
@@ -6,6 +6,9 @@ namespace Heisenburger69\BurgerSpawners\Entities;
 
 use pocketmine\entity\Animal;
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class Cow extends Animal {
 
@@ -19,9 +22,21 @@ class Cow extends Animal {
     }
 
     public function getDrops(): array{
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
         return [
-            Item::get(Item::RAW_BEEF, 0, mt_rand(1, 3)),
-            Item::get(Item::LEATHER, 0, mt_rand(0, 2)),
+            Item::get(Item::RAW_BEEF, 0, mt_rand(1, 3 * $lootingL)),
+            Item::get(Item::LEATHER, 0, mt_rand(0, 2 * $lootingL)),
         ];
     }
 }

--- a/src/Heisenburger69/BurgerSpawners/Entities/Cow.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Cow.php
@@ -16,7 +16,6 @@ class Cow extends Animal {
 
     public $width = 0.9;
     public $height = 1.3;
-    public $lootingL;
 
     public function getName(): string{
         return "Cow";
@@ -27,6 +26,7 @@ class Cow extends Animal {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Cow.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Cow.php
@@ -22,6 +22,7 @@ class Cow extends Animal {
     }
 
     public function getDrops(): array{
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Cow.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Cow.php
@@ -27,7 +27,7 @@ class Cow extends Animal {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+                
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Creeper.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Creeper.php
@@ -25,6 +25,7 @@ class Creeper extends Monster
 
     public function getDrops(): array
     {
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Creeper.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Creeper.php
@@ -30,7 +30,7 @@ class Creeper extends Monster
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+              
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Creeper.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Creeper.php
@@ -16,7 +16,6 @@ class Creeper extends Monster
 
     public $height = 1.7;
     public $width = 0.6;
-    public $lootingL;
 
 
     public function getName(): string
@@ -30,6 +29,7 @@ class Creeper extends Monster
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Creeper.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Creeper.php
@@ -5,6 +5,9 @@ namespace Heisenburger69\BurgerSpawners\Entities;
 
 use pocketmine\entity\Monster;
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class Creeper extends Monster
 {
@@ -22,8 +25,20 @@ class Creeper extends Monster
 
     public function getDrops(): array
     {
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
         if (mt_rand(1, 10) < 3) {
-            return [Item::get(Item::GUNPOWDER, 0, 1)];
+            return [Item::get(Item::GUNPOWDER, 0, 1 * $lootingL)];
         }
 
         return [];

--- a/src/Heisenburger69/BurgerSpawners/Entities/Creeper.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Creeper.php
@@ -16,6 +16,7 @@ class Creeper extends Monster
 
     public $height = 1.7;
     public $width = 0.6;
+    public $lootingL;
 
 
     public function getName(): string

--- a/src/Heisenburger69/BurgerSpawners/Entities/Donkey.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Donkey.php
@@ -17,6 +17,7 @@ class Donkey extends Animal
     /** @var float */
     public $length = 0.9;
     public $height = 0;
+    public $lootingL;
 
     public function getName(): string
     {

--- a/src/Heisenburger69/BurgerSpawners/Entities/Donkey.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Donkey.php
@@ -4,6 +4,9 @@ namespace Heisenburger69\BurgerSpawners\Entities;
 
 use pocketmine\entity\Animal;
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class Donkey extends Animal
 {
@@ -22,8 +25,20 @@ class Donkey extends Animal
 
     public function getDrops(): array
     {
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
         return $drops = [
-            Item::get(Item::LEATHER, 0, mt_rand(0, 2)),
+            Item::get(Item::LEATHER, 0, mt_rand(0, 2 * $lootingL)),
         ];
     }
 }

--- a/src/Heisenburger69/BurgerSpawners/Entities/Donkey.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Donkey.php
@@ -25,6 +25,7 @@ class Donkey extends Animal
 
     public function getDrops(): array
     {
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Donkey.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Donkey.php
@@ -17,7 +17,6 @@ class Donkey extends Animal
     /** @var float */
     public $length = 0.9;
     public $height = 0;
-    public $lootingL;
 
     public function getName(): string
     {
@@ -30,6 +29,7 @@ class Donkey extends Animal
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Donkey.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Donkey.php
@@ -30,7 +30,7 @@ class Donkey extends Animal
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+              
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/ElderGuardian.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/ElderGuardian.php
@@ -6,6 +6,9 @@ namespace Heisenburger69\BurgerSpawners\Entities;
 
 use pocketmine\entity\Monster;
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class ElderGuardian extends Monster {
 
@@ -19,9 +22,21 @@ class ElderGuardian extends Monster {
     }
 
     public function getDrops(): array{
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
         return [
-            Item::get(Item::PRISMARINE_CRYSTALS, 0, mt_rand(0, 1)),
-            Item::get(Item::PRISMARINE_SHARD, 0, mt_rand(0, 2)),
+            Item::get(Item::PRISMARINE_CRYSTALS, 0, mt_rand(0, 1 * $lootingL)),
+            Item::get(Item::PRISMARINE_SHARD, 0, mt_rand(0, 2 * $lootingL)),
         ];
     }
 }

--- a/src/Heisenburger69/BurgerSpawners/Entities/ElderGuardian.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/ElderGuardian.php
@@ -22,6 +22,7 @@ class ElderGuardian extends Monster {
     }
 
     public function getDrops(): array{
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/ElderGuardian.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/ElderGuardian.php
@@ -27,7 +27,7 @@ class ElderGuardian extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+              
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/ElderGuardian.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/ElderGuardian.php
@@ -16,6 +16,7 @@ class ElderGuardian extends Monster {
 
     public $width = 1.9975;
     public $height = 1.9975;
+    public $lootingL;
 
     public function getName(): string{
         return "Elder Guardian";

--- a/src/Heisenburger69/BurgerSpawners/Entities/ElderGuardian.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/ElderGuardian.php
@@ -16,7 +16,6 @@ class ElderGuardian extends Monster {
 
     public $width = 1.9975;
     public $height = 1.9975;
-    public $lootingL;
 
     public function getName(): string{
         return "Elder Guardian";
@@ -27,6 +26,7 @@ class ElderGuardian extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Enderman.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Enderman.php
@@ -22,6 +22,7 @@ class Enderman extends Monster {
     }
 
     public function getDrops(): array{
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Enderman.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Enderman.php
@@ -16,7 +16,6 @@ class Enderman extends Monster {
     /** @var float */
     public $length = 0.9;
     public $height = 1.8;
-    public $lootingL;
 
     public function getName(): string{
         return "Enderman";
@@ -27,6 +26,7 @@ class Enderman extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+               /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Enderman.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Enderman.php
@@ -16,6 +16,7 @@ class Enderman extends Monster {
     /** @var float */
     public $length = 0.9;
     public $height = 1.8;
+    public $lootingL;
 
     public function getName(): string{
         return "Enderman";

--- a/src/Heisenburger69/BurgerSpawners/Entities/Enderman.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Enderman.php
@@ -4,6 +4,9 @@ namespace Heisenburger69\BurgerSpawners\Entities;
 
 use pocketmine\entity\Monster;
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class Enderman extends Monster {
 
@@ -19,8 +22,20 @@ class Enderman extends Monster {
     }
 
     public function getDrops(): array{
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
         return [
-            Item::get(Item::ENDER_PEARL, 0, mt_rand(0, 1)),
+            Item::get(Item::ENDER_PEARL, 0, mt_rand(0, 1 * $lootingL)),
         ];
     }
 }

--- a/src/Heisenburger69/BurgerSpawners/Entities/Enderman.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Enderman.php
@@ -27,7 +27,7 @@ class Enderman extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-               /** @var Enchantment $looting */
+               
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/EntityManager.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/EntityManager.php
@@ -48,10 +48,12 @@ class EntityManager extends Entity //Teaspoon <3
         self::registerEntity(Spider::class, true, ['Spider', 'minecraft:spider']);
         self::registerEntity(Stray::class, true, ['Stray', 'minecraft:stray']);
         self::registerEntity(Vex::class, true, ['Vex', 'minecraft:vex']);
+        self::registerEntity(Villager::class, true, ['Villager', 'minecraft:villager']);
         self::registerEntity(Vindicator::class, true, ['Vindicator', 'minecraft:vindicator']);
         self::registerEntity(Witch::class, true, ['Witch', 'minecraft:witch']);
         self::registerEntity(WitherSkeleton::class, true, ['WitherSkeleton', 'minecraft:witherskeleton']);
         self::registerEntity(Wolf::class, true, ['Wolf', 'minecraft:wolf']);
+        self::registerEntity(Zombie::class, true, ['Zombie', 'minecraft:zombie']);
         self::registerEntity(ZombieVillager::class, true, ['ZombieVillager', 'minecraft:zombievillager']);
     }
 }

--- a/src/Heisenburger69/BurgerSpawners/Entities/EntityManager.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/EntityManager.php
@@ -48,7 +48,6 @@ class EntityManager extends Entity //Teaspoon <3
         self::registerEntity(Spider::class, true, ['Spider', 'minecraft:spider']);
         self::registerEntity(Stray::class, true, ['Stray', 'minecraft:stray']);
         self::registerEntity(Vex::class, true, ['Vex', 'minecraft:vex']);
-        self::registerEntity(Villager::class, true, ['Villager', 'minecraft:villager']);
         self::registerEntity(Vindicator::class, true, ['Vindicator', 'minecraft:vindicator']);
         self::registerEntity(Witch::class, true, ['Witch', 'minecraft:witch']);
         self::registerEntity(WitherSkeleton::class, true, ['WitherSkeleton', 'minecraft:witherskeleton']);

--- a/src/Heisenburger69/BurgerSpawners/Entities/EntityManager.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/EntityManager.php
@@ -48,6 +48,7 @@ class EntityManager extends Entity //Teaspoon <3
         self::registerEntity(Spider::class, true, ['Spider', 'minecraft:spider']);
         self::registerEntity(Stray::class, true, ['Stray', 'minecraft:stray']);
         self::registerEntity(Vex::class, true, ['Vex', 'minecraft:vex']);
+        self::registerEntity(Villager::class, true, ['Villager', 'minecraft:villager']);
         self::registerEntity(Vindicator::class, true, ['Vindicator', 'minecraft:vindicator']);
         self::registerEntity(Witch::class, true, ['Witch', 'minecraft:witch']);
         self::registerEntity(WitherSkeleton::class, true, ['WitherSkeleton', 'minecraft:witherskeleton']);

--- a/src/Heisenburger69/BurgerSpawners/Entities/EntityManager.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/EntityManager.php
@@ -48,12 +48,10 @@ class EntityManager extends Entity //Teaspoon <3
         self::registerEntity(Spider::class, true, ['Spider', 'minecraft:spider']);
         self::registerEntity(Stray::class, true, ['Stray', 'minecraft:stray']);
         self::registerEntity(Vex::class, true, ['Vex', 'minecraft:vex']);
-        self::registerEntity(Villager::class, true, ['Villager', 'minecraft:villager']);
         self::registerEntity(Vindicator::class, true, ['Vindicator', 'minecraft:vindicator']);
         self::registerEntity(Witch::class, true, ['Witch', 'minecraft:witch']);
         self::registerEntity(WitherSkeleton::class, true, ['WitherSkeleton', 'minecraft:witherskeleton']);
         self::registerEntity(Wolf::class, true, ['Wolf', 'minecraft:wolf']);
-        self::registerEntity(Zombie::class, true, ['Zombie', 'minecraft:zombie']);
         self::registerEntity(ZombieVillager::class, true, ['ZombieVillager', 'minecraft:zombievillager']);
     }
 }

--- a/src/Heisenburger69/BurgerSpawners/Entities/EntityManager.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/EntityManager.php
@@ -52,6 +52,7 @@ class EntityManager extends Entity //Teaspoon <3
         self::registerEntity(Witch::class, true, ['Witch', 'minecraft:witch']);
         self::registerEntity(WitherSkeleton::class, true, ['WitherSkeleton', 'minecraft:witherskeleton']);
         self::registerEntity(Wolf::class, true, ['Wolf', 'minecraft:wolf']);
+        self::registerEntity(Zombie::class, true, ['Zombie', 'minecraft:zombie']);
         self::registerEntity(ZombieVillager::class, true, ['ZombieVillager', 'minecraft:zombievillager']);
     }
 }

--- a/src/Heisenburger69/BurgerSpawners/Entities/Evoker.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Evoker.php
@@ -25,7 +25,7 @@ class Evoker extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+             
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Evoker.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Evoker.php
@@ -14,6 +14,7 @@ class Evoker extends Monster {
 
     public $width = 0.6;
     public $height = 1.95;
+    public $lootingL;
 
     public function getName(): string{
         return "Evoker";

--- a/src/Heisenburger69/BurgerSpawners/Entities/Evoker.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Evoker.php
@@ -14,7 +14,6 @@ class Evoker extends Monster {
 
     public $width = 0.6;
     public $height = 1.95;
-    public $lootingL;
 
     public function getName(): string{
         return "Evoker";
@@ -25,6 +24,7 @@ class Evoker extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Evoker.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Evoker.php
@@ -20,6 +20,7 @@ class Evoker extends Monster {
     }
 
     public function getDrops(): array{
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Evoker.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Evoker.php
@@ -4,6 +4,9 @@ namespace Heisenburger69\BurgerSpawners\Entities;
 
 use pocketmine\entity\Monster;
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class Evoker extends Monster {
 
@@ -17,8 +20,20 @@ class Evoker extends Monster {
     }
 
     public function getDrops(): array{
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
         return [
-            Item::get(Item::EMERALD, 0, mt_rand(0, 1))
+            Item::get(Item::EMERALD, 0, mt_rand(0, 1 * $lootingL))
         ];
     }
 }

--- a/src/Heisenburger69/BurgerSpawners/Entities/Fox.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Fox.php
@@ -40,25 +40,24 @@ class Fox extends Living
     }
 
     public function getDrops(): array{
-        $lootingL = 0;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
-            $damager = $cause->getDamager();
-            if($damager instanceof Player){
-                $looting = $damager->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();
                 }else{
-                    $lootingL = 0;
-                }
+                    $lootingL = 1;
+            }
             }
         }
-        $drops = [Item::get(Item::RABBIT_HIDE, 0, mt_rand(0, 1))];
+        $drops = [Item::get(Item::RABBIT_HIDE, 0, mt_rand(0, 1 * $lootingL))];
         if(mt_rand(1, 200) <= (5 + 2 * $lootingL)){
-            $drops[] = Item::get(Item::RABBIT_FOOT, 0, 1);
+            $drops[] = Item::get(Item::RABBIT_FOOT, 0, 1 * $lootingL);
         }
         if(mt_rand(1, 200) <= (5 + 2 * $lootingL)){
-            $drops[] = Item::get(Item::EMERALD, 0, 1);
+            $drops[] = Item::get(Item::EMERALD, 0, 1 * $lootingL);
         }
 
         return $drops;

--- a/src/Heisenburger69/BurgerSpawners/Entities/Fox.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Fox.php
@@ -17,6 +17,7 @@ class Fox extends Living
 
     public $width = 0.7;
     public $height = 0.6;
+    public $lootingL;
 
     public function getName(): string
     {

--- a/src/Heisenburger69/BurgerSpawners/Entities/Fox.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Fox.php
@@ -17,7 +17,6 @@ class Fox extends Living
 
     public $width = 0.7;
     public $height = 0.6;
-    public $lootingL;
 
     public function getName(): string
     {
@@ -45,6 +44,7 @@ class Fox extends Living
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Fox.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Fox.php
@@ -45,7 +45,7 @@ class Fox extends Living
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+              
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Fox.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Fox.php
@@ -40,6 +40,7 @@ class Fox extends Living
     }
 
     public function getDrops(): array{
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Ghast.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Ghast.php
@@ -16,6 +16,7 @@ class Ghast extends Monster {
     /** @var int */
     public $length = 6;
     public $height = 6;
+    public $lootingL;
 
     public function getName(): string{
         return "Ghast";

--- a/src/Heisenburger69/BurgerSpawners/Entities/Ghast.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Ghast.php
@@ -28,7 +28,7 @@ class Ghast extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+              
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Ghast.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Ghast.php
@@ -4,6 +4,9 @@ namespace Heisenburger69\BurgerSpawners\Entities;
 
 use pocketmine\entity\Monster;
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class Ghast extends Monster {
 
@@ -19,13 +22,25 @@ class Ghast extends Monster {
     }
 
     public function getDrops(): array{
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
         if(mt_rand(0, 1) == 1){
             $drops = [
-                Item::get(Item::GUNPOWDER, 0, mt_rand(0, 1)),
+                Item::get(Item::GUNPOWDER, 0, mt_rand(0, 1 * $lootingL)),
             ];
         }else{
             $drops = [
-                Item::get(Item::GHAST_TEAR, 0, 1),
+                Item::get(Item::GHAST_TEAR, 0, 1 * $lootingL),
             ];
         }
         return $drops;

--- a/src/Heisenburger69/BurgerSpawners/Entities/Ghast.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Ghast.php
@@ -23,6 +23,7 @@ class Ghast extends Monster {
     }
 
     public function getDrops(): array{
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Ghast.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Ghast.php
@@ -27,6 +27,7 @@ class Ghast extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Ghast.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Ghast.php
@@ -16,7 +16,6 @@ class Ghast extends Monster {
     /** @var int */
     public $length = 6;
     public $height = 6;
-    public $lootingL;
 
     public function getName(): string{
         return "Ghast";

--- a/src/Heisenburger69/BurgerSpawners/Entities/Guardian.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Guardian.php
@@ -4,6 +4,9 @@ namespace Heisenburger69\BurgerSpawners\Entities;
 
 use pocketmine\entity\Monster;
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class Guardian extends Monster
 {
@@ -26,9 +29,21 @@ class Guardian extends Monster
 
     public function getDrops(): array
     {
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
         return [
-            Item::get(Item::RAW_FISH, 0, mt_rand(1, 2)),
-            Item::get(Item::PRISMARINE_SHARD, 0, mt_rand(0, 1)),
+            Item::get(Item::RAW_FISH, 0, mt_rand(1, 2 * $lootingL)),
+            Item::get(Item::PRISMARINE_SHARD, 0, mt_rand(0, 1 * $lootingL)),
         ];
     }
 }

--- a/src/Heisenburger69/BurgerSpawners/Entities/Guardian.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Guardian.php
@@ -29,6 +29,7 @@ class Guardian extends Monster
 
     public function getDrops(): array
     {
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Guardian.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Guardian.php
@@ -34,7 +34,7 @@ class Guardian extends Monster
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+             
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Guardian.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Guardian.php
@@ -15,7 +15,6 @@ class Guardian extends Monster
 
     public $width = 0.85;
     public $height = 0.85;
-    public $lootingL;
 
     public function getName(): string
     {
@@ -34,6 +33,7 @@ class Guardian extends Monster
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Guardian.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Guardian.php
@@ -15,6 +15,7 @@ class Guardian extends Monster
 
     public $width = 0.85;
     public $height = 0.85;
+    public $lootingL;
 
     public function getName(): string
     {

--- a/src/Heisenburger69/BurgerSpawners/Entities/Horse.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Horse.php
@@ -28,7 +28,7 @@ class Horse extends Animal
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+             
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Horse.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Horse.php
@@ -13,7 +13,6 @@ class Horse extends Animal
 
     public $width = 2;
     public $height = 3;
-    public $lootingL;
 
     public const NETWORK_ID = self::HORSE;
 
@@ -28,6 +27,7 @@ class Horse extends Animal
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Horse.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Horse.php
@@ -23,6 +23,7 @@ class Horse extends Animal
 
     public function getDrops(): array
     {
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Horse.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Horse.php
@@ -4,6 +4,9 @@ namespace Heisenburger69\BurgerSpawners\Entities;
 
 use pocketmine\entity\Animal;
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class Horse extends Animal
 {
@@ -20,8 +23,20 @@ class Horse extends Animal
 
     public function getDrops(): array
     {
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
         return $drops = [
-            Item::get(Item::LEATHER, 0, mt_rand(0, 2)),
+            Item::get(Item::LEATHER, 0, mt_rand(0, 2 * $lootingL)),
         ];
     }
 }

--- a/src/Heisenburger69/BurgerSpawners/Entities/Horse.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Horse.php
@@ -13,6 +13,7 @@ class Horse extends Animal
 
     public $width = 2;
     public $height = 3;
+    public $lootingL;
 
     public const NETWORK_ID = self::HORSE;
 

--- a/src/Heisenburger69/BurgerSpawners/Entities/IronGolem.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/IronGolem.php
@@ -4,6 +4,9 @@ namespace Heisenburger69\BurgerSpawners\Entities;
 
 use pocketmine\entity\Animal;
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class IronGolem extends Animal
 {
@@ -25,8 +28,20 @@ class IronGolem extends Animal
 
     public function getDrops(): array
     {
-        $iron = Item::get(Item::IRON_INGOT, 0, mt_rand(1, 2));
-        $rose = Item::get(Item::RED_FLOWER, 0, 1);
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
+        $iron = Item::get(Item::IRON_INGOT, 0, mt_rand(1, 2 * $lootingL));
+        $rose = Item::get(Item::RED_FLOWER, 0, 1 * $lootingL);
         if(mt_rand(0, 5) === 0) {
             return [$iron, $rose];
         }

--- a/src/Heisenburger69/BurgerSpawners/Entities/IronGolem.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/IronGolem.php
@@ -28,6 +28,7 @@ class IronGolem extends Animal
 
     public function getDrops(): array
     {
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/IronGolem.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/IronGolem.php
@@ -15,6 +15,7 @@ class IronGolem extends Animal
 
     public $width = 1.4;
     public $height = 2.7;
+    public $lootingL;
 
     public function getName(): string
     {

--- a/src/Heisenburger69/BurgerSpawners/Entities/IronGolem.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/IronGolem.php
@@ -33,7 +33,7 @@ class IronGolem extends Animal
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+              
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/IronGolem.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/IronGolem.php
@@ -15,7 +15,6 @@ class IronGolem extends Animal
 
     public $width = 1.4;
     public $height = 2.7;
-    public $lootingL;
 
     public function getName(): string
     {
@@ -33,6 +32,7 @@ class IronGolem extends Animal
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Llama.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Llama.php
@@ -16,6 +16,7 @@ class Llama extends Animal
 
     public $width = 0.9;
     public $height = 1.87;
+    public $lootingL;
 
     public function getName(): string
     {

--- a/src/Heisenburger69/BurgerSpawners/Entities/Llama.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Llama.php
@@ -4,6 +4,9 @@ namespace Heisenburger69\BurgerSpawners\Entities;
 
 use pocketmine\entity\{Animal, Entity};
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class Llama extends Animal
 {
@@ -28,8 +31,20 @@ class Llama extends Animal
 
     public function getDrops(): array
     {
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
         return [
-            Item::get(Item::LEATHER, 0, mt_rand(0, 2)),
+            Item::get(Item::LEATHER, 0, mt_rand(0, 2 * $lootingL)),
         ];
     }
 }

--- a/src/Heisenburger69/BurgerSpawners/Entities/Llama.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Llama.php
@@ -16,7 +16,6 @@ class Llama extends Animal
 
     public $width = 0.9;
     public $height = 1.87;
-    public $lootingL;
 
     public function getName(): string
     {
@@ -36,6 +35,7 @@ class Llama extends Animal
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Llama.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Llama.php
@@ -36,7 +36,7 @@ class Llama extends Animal
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+              
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Llama.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Llama.php
@@ -31,6 +31,7 @@ class Llama extends Animal
 
     public function getDrops(): array
     {
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/MagmaCube.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/MagmaCube.php
@@ -4,6 +4,9 @@ namespace Heisenburger69\BurgerSpawners\Entities;
 
 use pocketmine\entity\Monster;
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class MagmaCube extends Monster {
 
@@ -15,7 +18,19 @@ class MagmaCube extends Monster {
 
     public function getDrops(): array
     {
-        return [Item::get(Item::MAGMA_CREAM, 0, mt_rand(0, 1))];
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
+        return [Item::get(Item::MAGMA_CREAM, 0, mt_rand(0, 1 * $lootingL))];
     }
 
 }

--- a/src/Heisenburger69/BurgerSpawners/Entities/MagmaCube.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/MagmaCube.php
@@ -23,7 +23,7 @@ class MagmaCube extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+               
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/MagmaCube.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/MagmaCube.php
@@ -11,7 +11,6 @@ use pocketmine\event\entity\EntityDamageByEntityEvent;
 class MagmaCube extends Monster {
 
     public const NETWORK_ID = self::MAGMA_CUBE;
-    public $lootingL;
 
     public function getName(): string{
         return "Magma Cube";
@@ -23,6 +22,7 @@ class MagmaCube extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/MagmaCube.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/MagmaCube.php
@@ -11,6 +11,7 @@ use pocketmine\event\entity\EntityDamageByEntityEvent;
 class MagmaCube extends Monster {
 
     public const NETWORK_ID = self::MAGMA_CUBE;
+    public $lootingL;
 
     public function getName(): string{
         return "Magma Cube";

--- a/src/Heisenburger69/BurgerSpawners/Entities/MagmaCube.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/MagmaCube.php
@@ -18,6 +18,7 @@ class MagmaCube extends Monster {
 
     public function getDrops(): array
     {
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Mooshroom.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Mooshroom.php
@@ -25,7 +25,7 @@ class Mooshroom extends Animal {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+           
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Mooshroom.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Mooshroom.php
@@ -14,7 +14,6 @@ class Mooshroom extends Animal {
 
     public $width = 0.9;
     public $height = 1.4;
-    public $lootingL;
 
     public function getName(): string{
         return "Mooshroom";
@@ -25,6 +24,7 @@ class Mooshroom extends Animal {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Mooshroom.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Mooshroom.php
@@ -20,6 +20,7 @@ class Mooshroom extends Animal {
     }
 
     public function getDrops(): array{
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Mooshroom.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Mooshroom.php
@@ -20,17 +20,21 @@ class Mooshroom extends Animal {
     }
 
     public function getDrops(): array{
-        $lootingL = 0;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                $lootingL = $dmg->getInventory()->getItemInHand()->getEnchantmentLevel(Enchantment::LOOTING);
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
             }
         }
         return [
-            Item::get(Item::RAW_BEEF, 0, mt_rand(1, 3 + $lootingL)),
-            Item::get(Item::LEATHER, 0, mt_rand(0, 2 + $lootingL)),
+            Item::get(Item::RAW_BEEF, 0, mt_rand(1, 3 * $lootingL)),
+            Item::get(Item::LEATHER, 0, mt_rand(0, 2 * $lootingL)),
         ];
     }
 }

--- a/src/Heisenburger69/BurgerSpawners/Entities/Mooshroom.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Mooshroom.php
@@ -14,6 +14,7 @@ class Mooshroom extends Animal {
 
     public $width = 0.9;
     public $height = 1.4;
+    public $lootingL;
 
     public function getName(): string{
         return "Mooshroom";

--- a/src/Heisenburger69/BurgerSpawners/Entities/Mule.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Mule.php
@@ -4,6 +4,9 @@ namespace Heisenburger69\BurgerSpawners\Entities;
 
 use pocketmine\entity\Animal;
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class Mule extends Animal {
 
@@ -22,8 +25,20 @@ class Mule extends Animal {
     }
 
     public function getDrops(): array{
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
         return [
-            Item::get(Item::LEATHER, 0, mt_rand(1, 2)),
+            Item::get(Item::LEATHER, 0, mt_rand(1, 2 * $lootingL)),
         ];
     }
 }

--- a/src/Heisenburger69/BurgerSpawners/Entities/Mule.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Mule.php
@@ -26,6 +26,7 @@ class Mule extends Animal {
     }
 
     public function getDrops(): array{
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Mule.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Mule.php
@@ -14,7 +14,7 @@ class Mule extends Animal {
 
     public $width = 1.3965;
     public $height = 1.6;
-    public $lootingL;
+
 
     public function getName(): string{
         return "Mule";
@@ -30,6 +30,7 @@ class Mule extends Animal {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Mule.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Mule.php
@@ -14,6 +14,7 @@ class Mule extends Animal {
 
     public $width = 1.3965;
     public $height = 1.6;
+    public $lootingL;
 
     public function getName(): string{
         return "Mule";

--- a/src/Heisenburger69/BurgerSpawners/Entities/Mule.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Mule.php
@@ -31,7 +31,7 @@ class Mule extends Animal {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+                
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Panda.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Panda.php
@@ -31,7 +31,7 @@ class Panda extends Animal
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+               
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Panda.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Panda.php
@@ -17,7 +17,7 @@ class Panda extends Animal
 
     public $width = 1.2;
     public $height = 1.2;
-    public $lootingL;
+  
 
     public function getName(): string
     {
@@ -30,6 +30,7 @@ class Panda extends Animal
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Panda.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Panda.php
@@ -26,6 +26,7 @@ class Panda extends Animal
 
     public function getDrops(): array
     {
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Panda.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Panda.php
@@ -17,6 +17,7 @@ class Panda extends Animal
 
     public $width = 1.2;
     public $height = 1.2;
+    public $lootingL;
 
     public function getName(): string
     {

--- a/src/Heisenburger69/BurgerSpawners/Entities/Panda.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Panda.php
@@ -6,6 +6,9 @@ namespace Heisenburger69\BurgerSpawners\Entities;
 
 use pocketmine\entity\Animal;
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class Panda extends Animal
 {
@@ -22,7 +25,19 @@ class Panda extends Animal
 
     public function getDrops(): array
     {
-        $item = Item::get(Item::SUGARCANE, 0, mt_rand(1, 3));
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
+        $item = Item::get(Item::SUGARCANE, 0, mt_rand(1, 3 * $lootingL));
         return [$item];
     }
 }

--- a/src/Heisenburger69/BurgerSpawners/Entities/Parrot.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Parrot.php
@@ -4,6 +4,9 @@ namespace Heisenburger69\BurgerSpawners\Entities;
 
 use pocketmine\entity\Animal;
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class Parrot extends Animal {
 
@@ -17,6 +20,18 @@ class Parrot extends Animal {
     }
 
     public function getDrops(): array{
-        return [Item::get(Item::FEATHER, 0, mt_rand(1, 2))];
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
+        return [Item::get(Item::FEATHER, 0, mt_rand(1, 2 * $lootingL))];
     }
 }

--- a/src/Heisenburger69/BurgerSpawners/Entities/Parrot.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Parrot.php
@@ -25,7 +25,7 @@ class Parrot extends Animal {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+          
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Parrot.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Parrot.php
@@ -14,6 +14,7 @@ class Parrot extends Animal {
 
     public $height = 0.9;
     public $width = 0.5;
+    public $lootingL;
 
     public function getName(): string{
         return "Parrot";

--- a/src/Heisenburger69/BurgerSpawners/Entities/Parrot.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Parrot.php
@@ -14,7 +14,6 @@ class Parrot extends Animal {
 
     public $height = 0.9;
     public $width = 0.5;
-    public $lootingL;
 
     public function getName(): string{
         return "Parrot";
@@ -25,6 +24,7 @@ class Parrot extends Animal {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Parrot.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Parrot.php
@@ -20,6 +20,7 @@ class Parrot extends Animal {
     }
 
     public function getDrops(): array{
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Pig.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Pig.php
@@ -4,6 +4,9 @@ namespace Heisenburger69\BurgerSpawners\Entities;
 
 use pocketmine\entity\Animal;
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class Pig extends Animal {
 
@@ -17,8 +20,20 @@ class Pig extends Animal {
     }
 
     public function getDrops(): array{
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
         return [
-            Item::get(Item::RAW_PORKCHOP, 0, mt_rand(1, 3)),
+            Item::get(Item::RAW_PORKCHOP, 0, mt_rand(1, 3 * $lootingL)),
         ];
     }
 }

--- a/src/Heisenburger69/BurgerSpawners/Entities/Pig.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Pig.php
@@ -25,7 +25,7 @@ class Pig extends Animal {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+              
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Pig.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Pig.php
@@ -20,6 +20,7 @@ class Pig extends Animal {
     }
 
     public function getDrops(): array{
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Pig.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Pig.php
@@ -14,7 +14,6 @@ class Pig extends Animal {
 
     public $width = 0.9;
     public $height = 0.9;
-    public $lootingL;
 
     public function getName(): string{
         return "Pig";
@@ -25,6 +24,7 @@ class Pig extends Animal {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Pig.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Pig.php
@@ -14,6 +14,7 @@ class Pig extends Animal {
 
     public $width = 0.9;
     public $height = 0.9;
+    public $lootingL;
 
     public function getName(): string{
         return "Pig";

--- a/src/Heisenburger69/BurgerSpawners/Entities/PigZombie.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/PigZombie.php
@@ -14,6 +14,7 @@ class PigZombie extends Monster {
 
     public $width = 0.6;
     public $height = 1.95;
+    public $lootingL;
 
     public function getName(): string{
         return "Zombie Pigman";

--- a/src/Heisenburger69/BurgerSpawners/Entities/PigZombie.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/PigZombie.php
@@ -14,8 +14,6 @@ class PigZombie extends Monster {
 
     public $width = 0.6;
     public $height = 1.95;
-    public $lootingL;
-
     public function getName(): string{
         return "Zombie Pigman";
     }
@@ -25,6 +23,7 @@ class PigZombie extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/PigZombie.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/PigZombie.php
@@ -4,6 +4,9 @@ namespace Heisenburger69\BurgerSpawners\Entities;
 
 use pocketmine\entity\Monster;
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class PigZombie extends Monster {
 
@@ -17,13 +20,25 @@ class PigZombie extends Monster {
     }
 
     public function getDrops(): array{
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
         $drops = [
-            Item::get(Item::GOLD_NUGGET, 0, mt_rand(0, 1)),
-            Item::get(Item::ROTTEN_FLESH, 0, mt_rand(0, 1)),
+            Item::get(Item::GOLD_NUGGET, 0, mt_rand(0, 1 * $lootingL)),
+            Item::get(Item::ROTTEN_FLESH, 0, mt_rand(0, 1 * $lootingL)),
         ];
 
         if(mt_rand(1, 200) <= 7){
-            $drops[] = Item::get(Item::GOLD_INGOT, 0, 1);
+            $drops[] = Item::get(Item::GOLD_INGOT, 0, 1 * $lootingL);
         }
         return $drops;
     }

--- a/src/Heisenburger69/BurgerSpawners/Entities/PigZombie.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/PigZombie.php
@@ -19,6 +19,7 @@ class PigZombie extends Monster {
     }
 
     public function getDrops(): array{
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/PigZombie.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/PigZombie.php
@@ -24,7 +24,7 @@ class PigZombie extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+           
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/PolarBear.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/PolarBear.php
@@ -30,7 +30,7 @@ class PolarBear extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+              
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/PolarBear.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/PolarBear.php
@@ -4,6 +4,9 @@ namespace Heisenburger69\BurgerSpawners\Entities;
 
 use pocketmine\entity\Monster;
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class PolarBear extends Monster {
 
@@ -22,9 +25,21 @@ class PolarBear extends Monster {
     }
 
     public function getDrops(): array{
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
         return [
-            Item::get(Item::RAW_SALMON, 0, mt_rand(0, 2)),
-            Item::get(Item::RAW_FISH, 0, mt_rand(0, 2)),
+            Item::get(Item::RAW_SALMON, 0, mt_rand(0, 2 * $lootingL)),
+            Item::get(Item::RAW_FISH, 0, mt_rand(0, 2 * $lootingL)),
         ];
     }
 }

--- a/src/Heisenburger69/BurgerSpawners/Entities/PolarBear.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/PolarBear.php
@@ -25,6 +25,7 @@ class PolarBear extends Monster {
     }
 
     public function getDrops(): array{
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/PolarBear.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/PolarBear.php
@@ -14,6 +14,7 @@ class PolarBear extends Monster {
 
     public $width = 1.3;
     public $height = 1.4;
+    public $lootingL;
 
     public function getName(): string{
         return "Polar Bear";

--- a/src/Heisenburger69/BurgerSpawners/Entities/PolarBear.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/PolarBear.php
@@ -14,7 +14,6 @@ class PolarBear extends Monster {
 
     public $width = 1.3;
     public $height = 1.4;
-    public $lootingL;
 
     public function getName(): string{
         return "Polar Bear";
@@ -30,6 +29,7 @@ class PolarBear extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Rabbit.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Rabbit.php
@@ -23,6 +23,7 @@ class Rabbit extends Animal {
     public const TAG_RABBIT_TYPE = "RabbitType";
     public $width = 0.4;
     public $height = 0.5;
+    public $lootingL;
 
     public function initEntity(): void{
         $type = $this->getRandomRabbitType();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Rabbit.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Rabbit.php
@@ -58,7 +58,7 @@ class Rabbit extends Animal {
     }
 
     public function getDrops(): array{
-        $lootingL = 0;
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $damager = $cause->getDamager();
@@ -68,7 +68,7 @@ class Rabbit extends Animal {
                 if($looting !== null){
                     $lootingL = $looting->getLevel();
                 }else{
-                    $lootingL = 0;
+                    $lootingL = 1;
                 }
             }
         }

--- a/src/Heisenburger69/BurgerSpawners/Entities/Rabbit.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Rabbit.php
@@ -71,9 +71,9 @@ class Rabbit extends Animal {
                 }
             }
         }
-        $drops = [Item::get(Item::RABBIT_HIDE, 0, mt_rand(0, 1))];
+        $drops = [Item::get(Item::RABBIT_HIDE, 0, mt_rand(0, 1 * $lootingL))];
         if(mt_rand(1, 200) <= (5 + 2 * $lootingL)){
-            $drops[] = Item::get(Item::RABBIT_FOOT, 0, 1);
+            $drops[] = Item::get(Item::RABBIT_FOOT, 0, 1 * $lootingL);
         }
 
         return $drops;

--- a/src/Heisenburger69/BurgerSpawners/Entities/Rabbit.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Rabbit.php
@@ -23,7 +23,6 @@ class Rabbit extends Animal {
     public const TAG_RABBIT_TYPE = "RabbitType";
     public $width = 0.4;
     public $height = 0.5;
-    public $lootingL;
 
     public function initEntity(): void{
         $type = $this->getRandomRabbitType();
@@ -64,6 +63,7 @@ class Rabbit extends Animal {
         if($cause instanceof EntityDamageByEntityEvent){
             $damager = $cause->getDamager();
             if($damager instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $damager->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Rabbit.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Rabbit.php
@@ -63,7 +63,7 @@ class Rabbit extends Animal {
         if($cause instanceof EntityDamageByEntityEvent){
             $damager = $cause->getDamager();
             if($damager instanceof Player){
-                /** @var Enchantment $looting */
+            
                 $looting = $damager->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Sheep.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Sheep.php
@@ -14,6 +14,7 @@ class Sheep extends Animal {
 
     public $width = 0.9;
     public $height = 1.3;
+    public $lootingL;
 
     public function getName(): string{
         return "Sheep";

--- a/src/Heisenburger69/BurgerSpawners/Entities/Sheep.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Sheep.php
@@ -25,7 +25,7 @@ class Sheep extends Animal {
         if($cause instanceof EntityDamageByEntityEvent){
             $damager = $cause->getDamager();
             if($damager instanceof Player){
-                /** @var Enchantment $looting */
+           
                 $looting = $damager->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Sheep.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Sheep.php
@@ -28,10 +28,10 @@ class Sheep extends Animal {
                 if($looting !== null){
                     $lootingL = $looting->getLevel();
                 }else{
-                    $lootingL = 0;
+                    $lootingL = 1;
                 }
-                $drops = [Item::get(Item::WOOL, mt_rand(0, 15), 1)]; //TODO: Check proper color
-                $drops[] = Item::get(Item::RAW_MUTTON, 0, mt_rand(1, 2 + $lootingL));
+                $drops = [Item::get(Item::WOOL, mt_rand(0, 15), 1 * $lootingL)]; //TODO: Check proper color
+                $drops[] = Item::get(Item::RAW_MUTTON, 0, mt_rand(1, 2 * $lootingL));
 
                 return $drops;
             }

--- a/src/Heisenburger69/BurgerSpawners/Entities/Sheep.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Sheep.php
@@ -20,6 +20,7 @@ class Sheep extends Animal {
     }
 
     public function getDrops(): array{
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $damager = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Sheep.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Sheep.php
@@ -14,7 +14,6 @@ class Sheep extends Animal {
 
     public $width = 0.9;
     public $height = 1.3;
-    public $lootingL;
 
     public function getName(): string{
         return "Sheep";
@@ -25,6 +24,7 @@ class Sheep extends Animal {
         if($cause instanceof EntityDamageByEntityEvent){
             $damager = $cause->getDamager();
             if($damager instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $damager->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Shulker.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Shulker.php
@@ -16,6 +16,7 @@ class Shulker extends Monster {
 
     public $width = 1;
     public $height = 1;
+    public $lootingL;
 
     public function getName(): string{
         return "Shulker";

--- a/src/Heisenburger69/BurgerSpawners/Entities/Shulker.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Shulker.php
@@ -28,6 +28,7 @@ class Shulker extends Monster {
     }
 
     public function getDrops(): array{
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Shulker.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Shulker.php
@@ -16,7 +16,6 @@ class Shulker extends Monster {
 
     public $width = 1;
     public $height = 1;
-    public $lootingL;
 
     public function getName(): string{
         return "Shulker";
@@ -33,6 +32,7 @@ class Shulker extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Shulker.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Shulker.php
@@ -6,6 +6,9 @@ use pocketmine\entity\{
     Entity, Monster
 };
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class Shulker extends Monster {
 
@@ -25,7 +28,19 @@ class Shulker extends Monster {
     }
 
     public function getDrops(): array{
-        return [Item::get(Item::SHULKER_SHELL, 0, mt_rand(0, 1))];
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
+        return [Item::get(Item::SHULKER_SHELL, 0, mt_rand(0, 1 * $lootingL))];
     }
 
     public function knockBack(Entity $attacker, float $damage, float $x, float $z, float $base = 0.4): void{

--- a/src/Heisenburger69/BurgerSpawners/Entities/Shulker.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Shulker.php
@@ -33,7 +33,7 @@ class Shulker extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+               
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Skeleton.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Skeleton.php
@@ -4,6 +4,9 @@ namespace Heisenburger69\BurgerSpawners\Entities;
 
 use pocketmine\entity\Monster;
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class Skeleton extends Monster {
 
@@ -17,9 +20,21 @@ class Skeleton extends Monster {
     }
 
     public function getDrops(): array{
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
         return [
-            Item::get(Item::ARROW, 0, mt_rand(0, 2)),
-            Item::get(Item::BONE, 0, mt_rand(0, 2)),
+            Item::get(Item::ARROW, 0, mt_rand(0, 2 * $lootingL)),
+            Item::get(Item::BONE, 0, mt_rand(0, 2 * $lootingL)),
         ];
     }
 }

--- a/src/Heisenburger69/BurgerSpawners/Entities/Skeleton.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Skeleton.php
@@ -25,7 +25,7 @@ class Skeleton extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+              
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Skeleton.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Skeleton.php
@@ -14,7 +14,6 @@ class Skeleton extends Monster {
 
     public $height = 1.99;
     public $width = 0.6;
-    public $lootingL;
 
     public function getName(): string{
         return "Skeleton";
@@ -25,6 +24,7 @@ class Skeleton extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Skeleton.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Skeleton.php
@@ -20,6 +20,7 @@ class Skeleton extends Monster {
     }
 
     public function getDrops(): array{
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Skeleton.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Skeleton.php
@@ -14,6 +14,7 @@ class Skeleton extends Monster {
 
     public $height = 1.99;
     public $width = 0.6;
+    public $lootingL;
 
     public function getName(): string{
         return "Skeleton";

--- a/src/Heisenburger69/BurgerSpawners/Entities/Slime.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Slime.php
@@ -21,6 +21,7 @@ class Slime extends Living {
     }
 
     public function getDrops(): array{
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Slime.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Slime.php
@@ -15,6 +15,7 @@ class Slime extends Living {
 
     public $width = 2.04;
     public $height = 2.04;
+    public $lootingL;
 
     public function getName(): string{
         return "Slime";

--- a/src/Heisenburger69/BurgerSpawners/Entities/Slime.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Slime.php
@@ -26,7 +26,7 @@ class Slime extends Living {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+            
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Slime.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Slime.php
@@ -6,6 +6,7 @@ use pocketmine\entity\Living;
 use pocketmine\event\entity\EntityDamageByEntityEvent;
 use pocketmine\item\Item;
 use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
 use function mt_rand;
 
 class Slime extends Living {
@@ -20,22 +21,32 @@ class Slime extends Living {
     }
 
     public function getDrops(): array{
-        $drops = [Item::get(Item::SLIMEBALL, 0, 1)];
-        if($this->lastDamageCause instanceof EntityDamageByEntityEvent and $this->lastDamageCause->getEntity() instanceof Player){
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
+        $drops = [Item::get(Item::SLIMEBALL, 0, 1 * $lootingL)];
             if(mt_rand(0, 199) < 5){
                 switch(mt_rand(0, 2)){
                     case 0:
-                        $drops[] = Item::get(Item::IRON_INGOT, 0, 1);
+                        $drops[] = Item::get(Item::IRON_INGOT, 0, 1 * $lootingL);
                         break;
                     case 1:
-                        $drops[] = Item::get(Item::CARROT, 0, 1);
+                        $drops[] = Item::get(Item::CARROT, 0, 1 * $lootingL);
                         break;
                     case 2:
-                        $drops[] = Item::get(Item::POTATO, 0, 1);
+                        $drops[] = Item::get(Item::POTATO, 0, 1 * $lootingL);
                         break;
                 }
             }
-        }
 
         return $drops;
     }

--- a/src/Heisenburger69/BurgerSpawners/Entities/Slime.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Slime.php
@@ -15,7 +15,6 @@ class Slime extends Living {
 
     public $width = 2.04;
     public $height = 2.04;
-    public $lootingL;
 
     public function getName(): string{
         return "Slime";
@@ -26,6 +25,7 @@ class Slime extends Living {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/SnowGolem.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/SnowGolem.php
@@ -11,6 +11,7 @@ use pocketmine\item\Shears;
 use pocketmine\math\Vector3;
 use pocketmine\nbt\tag\ByteTag;
 use pocketmine\Player;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 use pocketmine\item\enchantment\Enchantment;
 
 class SnowGolem extends Monster {

--- a/src/Heisenburger69/BurgerSpawners/Entities/SnowGolem.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/SnowGolem.php
@@ -11,6 +11,7 @@ use pocketmine\item\Shears;
 use pocketmine\math\Vector3;
 use pocketmine\nbt\tag\ByteTag;
 use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
 
 class SnowGolem extends Monster {
 
@@ -31,6 +32,18 @@ class SnowGolem extends Monster {
     }
 
     public function getDrops(): array{
-        return [Item::get(Item::SNOWBALL, 0, mt_rand(0, 15))];
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
+        return [Item::get(Item::SNOWBALL, 0, mt_rand(0, 15 * $lootingL))];
     }
 }

--- a/src/Heisenburger69/BurgerSpawners/Entities/SnowGolem.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/SnowGolem.php
@@ -34,6 +34,7 @@ class SnowGolem extends Monster {
     }
 
     public function getDrops(): array{
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/SnowGolem.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/SnowGolem.php
@@ -11,8 +11,8 @@ use pocketmine\item\Shears;
 use pocketmine\math\Vector3;
 use pocketmine\nbt\tag\ByteTag;
 use pocketmine\Player;
-use pocketmine\event\entity\EntityDamageByEntityEvent;
 use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class SnowGolem extends Monster {
 
@@ -21,6 +21,7 @@ class SnowGolem extends Monster {
 
     public $width = 0.7;
     public $height = 1.9;
+    public $lootingL;
 
     public function getName(): string{
         return "Snow Golem";

--- a/src/Heisenburger69/BurgerSpawners/Entities/SnowGolem.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/SnowGolem.php
@@ -21,7 +21,7 @@ class SnowGolem extends Monster {
 
     public $width = 0.7;
     public $height = 1.9;
-    public $lootingL;
+  
 
     public function getName(): string{
         return "Snow Golem";
@@ -38,6 +38,7 @@ class SnowGolem extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/SnowGolem.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/SnowGolem.php
@@ -39,7 +39,7 @@ class SnowGolem extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+              
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Spider.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Spider.php
@@ -17,6 +17,7 @@ class Spider extends Monster {
 
     public $width = 1.4;
     public $height = 0.9;
+    public $lootingL;
 
     public function getName(): string{
         return "Spider";

--- a/src/Heisenburger69/BurgerSpawners/Entities/Spider.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Spider.php
@@ -17,7 +17,6 @@ class Spider extends Monster {
 
     public $width = 1.4;
     public $height = 0.9;
-    public $lootingL;
 
     public function getName(): string{
         return "Spider";
@@ -28,6 +27,7 @@ class Spider extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Spider.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Spider.php
@@ -28,7 +28,7 @@ class Spider extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+             
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Spider.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Spider.php
@@ -23,6 +23,7 @@ class Spider extends Monster {
     }
 
     public function getDrops(): array{
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Spider.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Spider.php
@@ -8,6 +8,7 @@ use pocketmine\entity\{
 use pocketmine\event\entity\EntityDamageByEntityEvent;
 use pocketmine\item\Item;
 use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
 use function mt_rand;
 
 class Spider extends Monster {
@@ -22,22 +23,32 @@ class Spider extends Monster {
     }
 
     public function getDrops(): array{
-        $drops = [Item::get(Item::STRING, 0, 1)];
-        if($this->lastDamageCause instanceof EntityDamageByEntityEvent and ($this->lastDamageCause->getEntity() instanceof Player || $this->lastDamageCause->getEntity() instanceof Human)){
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
+        $drops = [Item::get(Item::STRING, 0, 1 * $lootingL)];
             if(mt_rand(0, 199) < 5){
                 switch(mt_rand(0, 2)){
                     case 0:
-                        $drops[] = Item::get(Item::IRON_INGOT, 0, 1);
+                        $drops[] = Item::get(Item::IRON_INGOT, 0, 1 * $lootingL);
                         break;
                     case 1:
-                        $drops[] = Item::get(Item::CARROT, 0, 1);
+                        $drops[] = Item::get(Item::CARROT, 0, 1 * $lootingL);
                         break;
                     case 2:
-                        $drops[] = Item::get(Item::POTATO, 0, 1);
+                        $drops[] = Item::get(Item::POTATO, 0, 1 * $lootingL);
                         break;
                 }
             }
-        }
 
         return $drops;
     }

--- a/src/Heisenburger69/BurgerSpawners/Entities/Vindicator.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Vindicator.php
@@ -26,6 +26,7 @@ class Vindicator extends Monster {
     }
 
     public function getDrops(): array{
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Vindicator.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Vindicator.php
@@ -14,7 +14,7 @@ class Vindicator extends Monster {
 
     public $width = 0.6;
     public $height = 1.95;
-    public $lootingL;
+
 
     public function getName(): string{
         return "Vindicator";
@@ -30,6 +30,7 @@ class Vindicator extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Vindicator.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Vindicator.php
@@ -14,6 +14,7 @@ class Vindicator extends Monster {
 
     public $width = 0.6;
     public $height = 1.95;
+    public $lootingL;
 
     public function getName(): string{
         return "Vindicator";

--- a/src/Heisenburger69/BurgerSpawners/Entities/Vindicator.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Vindicator.php
@@ -4,6 +4,9 @@ namespace Heisenburger69\BurgerSpawners\Entities;
 
 use pocketmine\entity\Monster;
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class Vindicator extends Monster {
 
@@ -22,8 +25,20 @@ class Vindicator extends Monster {
     }
 
     public function getDrops(): array{
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
         return [
-            Item::get(Item::EMERALD, 0, mt_rand(0, 1)),
+            Item::get(Item::EMERALD, 0, mt_rand(0, 1 * $lootingL)),
         ];
     }
 }

--- a/src/Heisenburger69/BurgerSpawners/Entities/Vindicator.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Vindicator.php
@@ -31,7 +31,7 @@ class Vindicator extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+           
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/WitherSkeleton.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/WitherSkeleton.php
@@ -29,7 +29,7 @@ class WitherSkeleton extends Skeleton {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+             
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/WitherSkeleton.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/WitherSkeleton.php
@@ -24,6 +24,7 @@ class WitherSkeleton extends Skeleton {
     }
 
     public function getDrops(): array{
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/WitherSkeleton.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/WitherSkeleton.php
@@ -13,7 +13,6 @@ class WitherSkeleton extends Skeleton {
 
     public $width = 0.7;
     public $height = 2.4;
-    public $lootingL;
 
     public function getName(): string{
         return "Wither Skeleton";
@@ -29,6 +28,7 @@ class WitherSkeleton extends Skeleton {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/WitherSkeleton.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/WitherSkeleton.php
@@ -13,6 +13,7 @@ class WitherSkeleton extends Skeleton {
 
     public $width = 0.7;
     public $height = 2.4;
+    public $lootingL;
 
     public function getName(): string{
         return "Wither Skeleton";

--- a/src/Heisenburger69/BurgerSpawners/Entities/WitherSkeleton.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/WitherSkeleton.php
@@ -3,6 +3,9 @@
 namespace Heisenburger69\BurgerSpawners\Entities;
 
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class WitherSkeleton extends Skeleton {
 
@@ -21,9 +24,21 @@ class WitherSkeleton extends Skeleton {
     }
 
     public function getDrops(): array{
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
         return [
-            Item::get(Item::COAL, 0, mt_rand(0, 1)),
-            Item::get(Item::BONE, 0, mt_rand(0, 2)),
+            Item::get(Item::COAL, 0, mt_rand(0, 1 * $lootingL)),
+            Item::get(Item::BONE, 0, mt_rand(0, 2 * $lootingL)),
         ];
     }
 }

--- a/src/Heisenburger69/BurgerSpawners/Entities/Wolf.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Wolf.php
@@ -14,7 +14,7 @@ class Wolf extends Animal {
 
     public $width = 0.6;
     public $height = 0.85;
-    public $lootingL;
+
 
     public function getName(): string{
         return "Wolf";
@@ -26,6 +26,7 @@ class Wolf extends Animal {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Wolf.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Wolf.php
@@ -22,6 +22,7 @@ class Wolf extends Animal {
 
     public function getDrops(): array
     {
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Wolf.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Wolf.php
@@ -4,6 +4,9 @@ namespace Heisenburger69\BurgerSpawners\Entities;
 
 use pocketmine\entity\Animal;
 use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 
 class Wolf extends Animal {
 
@@ -18,6 +21,18 @@ class Wolf extends Animal {
 
     public function getDrops(): array
     {
-        return [Item::get(Item::BONE, 0, mt_rand(0, 3))];
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
+        return [Item::get(Item::BONE, 0, mt_rand(0, 3 * $lootingL))];
     }
 }

--- a/src/Heisenburger69/BurgerSpawners/Entities/Wolf.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Wolf.php
@@ -27,7 +27,7 @@ class Wolf extends Animal {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+          
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Wolf.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Wolf.php
@@ -14,6 +14,7 @@ class Wolf extends Animal {
 
     public $width = 0.6;
     public $height = 0.85;
+    public $lootingL;
 
     public function getName(): string{
         return "Wolf";

--- a/src/Heisenburger69/BurgerSpawners/Entities/Zombie.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Zombie.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Heisenburger69\BurgerSpawners\Entities;
+
+use pocketmine\entity\Monster;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
+use pocketmine\item\Item;
+use pocketmine\item\ItemFactory;
+use pocketmine\Player;
+use pocketmine\item\enchantment\Enchantment;
+class Zombie extends Monster {
+
+    public const NETWORK_ID = self::ZOMBIE;
+
+    public $width = 0.6;
+    public $height = 1.95;
+    public $lootingL;
+
+    public function getName(): string{
+        return "Zombie";
+    }
+
+    public function initEntity(): void{
+        $this->setMaxHealth(20);
+        parent::initEntity();
+    }
+
+    public function getDrops(): array{
+        $cause = $this->lastDamageCause;
+        if($cause instanceof EntityDamageByEntityEvent){
+            $dmg = $cause->getDamager();
+            if($dmg instanceof Player){
+                $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
+                if($looting !== null){
+                    $lootingL = $looting->getLevel();
+                }else{
+                    $lootingL = 1;
+            }
+            }
+        }
+                $drops = [
+                    ItemFactory::get(Item::ROTTEN_FLESH, 0, mt_rand(0, 2 * $lootingL))
+                ];
+        
+                if(mt_rand(0, 199) < 5){
+                    switch(mt_rand(0, 2)){
+                        case 0:
+                            $drops[] = ItemFactory::get(Item::IRON_INGOT, 0, 1 * $lootingL);
+                            break;
+                        case 1:
+                            $drops[] = ItemFactory::get(Item::CARROT, 0, 1 * $lootingL);
+                            break;
+                        case 2:
+                            $drops[] = ItemFactory::get(Item::POTATO, 0, 1 * $lootingL);
+                            break;
+                    }
+                }
+        
+                return $drops;
+            }
+    }

--- a/src/Heisenburger69/BurgerSpawners/Entities/Zombie.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Zombie.php
@@ -30,7 +30,7 @@ class Zombie extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
-                /** @var Enchantment $looting */
+            
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Zombie.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Zombie.php
@@ -14,7 +14,6 @@ class Zombie extends Monster {
 
     public $width = 0.6;
     public $height = 1.95;
-    public $lootingL;
 
     public function getName(): string{
         return "Zombie";
@@ -30,6 +29,7 @@ class Zombie extends Monster {
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();
             if($dmg instanceof Player){
+                /** @var Enchantment $looting */
                 $looting = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING);
                 if($looting !== null){
                     $lootingL = $looting->getLevel();

--- a/src/Heisenburger69/BurgerSpawners/Entities/Zombie.php
+++ b/src/Heisenburger69/BurgerSpawners/Entities/Zombie.php
@@ -25,6 +25,7 @@ class Zombie extends Monster {
     }
 
     public function getDrops(): array{
+        $lootingL = 1;
         $cause = $this->lastDamageCause;
         if($cause instanceof EntityDamageByEntityEvent){
             $dmg = $cause->getDamager();


### PR DESCRIPTION
Okay, I saw some of the code had some basic Looting enchantment implementation. It was okay, but didn't fit its needs of a looting basic enchantment. I did see this on your to-do list though, so I thought I'd save you the bother of doing it yourself, and allowing me to implement this. By "Basic Looting Enchantment", I'm assuming you mean add Looting enchantment drops on all of the mobs?
If so, then this is the Pull Request for you.

## What does this Pull Request add to the plugin?
So this plugin adds basic looting enchantment on all of the mobs that include getDrops() array function. Those that do not, were probably missed out on by the plugin on purpose. If not, I'll just let you implement more drops for the other mobs. If not, then don't worry. I never conflicted those with the non dropped mobs.
This plugin also implements rewrites to the Looting enchantment. This is because adding a + before the looting level isn't very efficient, especially in vanilla. This needs to multiply by the looting level, not adding onto it.
This isn't how vanilla works.

So for example, if I had a looting 3 enchantment level, it'd multiply the drops by 3. Adding onto it just doesn't work very well with Looting. Since Looting levels matter. If you add onto the looting levels, then looting levels are basically pointless, because it's adding one onto it every by level, and not multiplying it. This is why I made a recode with Looting levels. No, this shouldn't require any major plugins for this to work.

Along with this, I've also ticked off Basic looting enchantment implementation in the Readme.MD file just so we know where we are at.

## Has this Pull Request been tested? 
Start up script - Tested to enable with success.
Mob killing / kills - Untested, but should work. There shouldn't be any other major issues to worry about. Untested, but everything should work as expected.
Thank you!