### PR TITLE
Fixed getFolderName() crashing the server (#38)

### DIFF
--- a/src/Heisenburger69/BurgerSpawners/EventListener.php
+++ b/src/Heisenburger69/BurgerSpawners/EventListener.php
@@ -73,8 +73,7 @@ class EventListener implements Listener
             if (in_array($entity->getId(), $this->plugin->exemptedEntities)) return; 
             if($entity->getLevel()->isClosed()) return;
             $disabledWorlds = ConfigManager::getArray("mob-stacking-disabled-worlds");
-            if (is_array($disabledWorlds)) {
-                
+            if (is_array($disabledWorlds)) { 
                 if (in_array($entity->getLevel()->getFolderName(), $disabledWorlds)) {
                     return;
                 }

--- a/src/Heisenburger69/BurgerSpawners/EventListener.php
+++ b/src/Heisenburger69/BurgerSpawners/EventListener.php
@@ -71,7 +71,7 @@ class EventListener implements Listener
         $entity = $event->getEntity();
         $this->plugin->getScheduler()->scheduleDelayedTask(new ClosureTask(function (int $currentTick) use ($entity): void {
             if (in_array($entity->getId(), $this->plugin->exemptedEntities)) return; 
-            if($entity->getLevel()->getFolderName() === null) return;
+            if($entity->getLevel()->isClosed()) return;
             $disabledWorlds = ConfigManager::getArray("mob-stacking-disabled-worlds");
             if (is_array($disabledWorlds)) {
                 

--- a/src/Heisenburger69/BurgerSpawners/EventListener.php
+++ b/src/Heisenburger69/BurgerSpawners/EventListener.php
@@ -70,15 +70,16 @@ class EventListener implements Listener
     {
         $entity = $event->getEntity();
         $this->plugin->getScheduler()->scheduleDelayedTask(new ClosureTask(function (int $currentTick) use ($entity): void {
-            if (in_array($entity->getId(), $this->plugin->exemptedEntities)) return;
-
+            if (in_array($entity->getId(), $this->plugin->exemptedEntities)) return; 
+            if($entity->getLevel()->getFolderName() === null) return;
             $disabledWorlds = ConfigManager::getArray("mob-stacking-disabled-worlds");
             if (is_array($disabledWorlds)) {
+                
                 if (in_array($entity->getLevel()->getFolderName(), $disabledWorlds)) {
                     return;
                 }
             }
-
+            
             if (ConfigManager::getToggle("allow-mob-stacking")) {
                 if ($entity instanceof Human or !$entity instanceof Living) return;
                 $mobStacker = new Mobstacker($entity);


### PR DESCRIPTION
This issue fixes #38 from crashing the server if the worlds in the config don’t exist, or has been unloaded. This issue mainly prevents server crashes. Though, you’d need to add worlds that exist in worlds/ folder instead of adding worlds that simply do not exist.

If the worlds set in config.yml do not exist, then the mob in that world will try to spawn.

This could also be useful for if you’re using plugins like PureEntities, and using auto spawn task, leading to the crash. In all, this fixes the crash issue #38 was occurring, since no one likes a server crash. ;P