### PR TITLE
Exclude all Entities that are not in the ArrayList.

### DIFF
--- a/src/Heisenburger69/BurgerSpawners/EventListener.php
+++ b/src/Heisenburger69/BurgerSpawners/EventListener.php
@@ -84,6 +84,7 @@ class EventListener implements Listener
     {
         $entity = $event->getEntity();
         $this->plugin->getScheduler()->scheduleDelayedTask(new ClosureTask(function (int $currentTick) use ($entity): void {
+            if(!in_array(strtolower($entity->getName()), Utils::getEntityArrayList())) return;
             if (in_array($entity->getId(), $this->plugin->exemptedEntities)) return;
             if($entity instanceof Living && in_array(Utils::getEntityNameFromID($entity->getId()), $this->plugin->exemptedEntities)) return;
             if($entity->getLevel() === null) return;


### PR DESCRIPTION
This prevents stacked onjectEntities like ArmorStands, Lore, etc. (what causes a Duplicating of the Content)