### PR TITLE
Fixed Item class not found

### DIFF
--- a/src/Heisenburger69/BurgerSpawners/Utilities/Mobstacker.php
+++ b/src/Heisenburger69/BurgerSpawners/Utilities/Mobstacker.php
@@ -8,6 +8,7 @@ use pocketmine\event\entity\EntityDeathEvent;
 use pocketmine\nbt\tag\IntTag;
 use pocketmine\Player;
 use pocketmine\utils\TextFormat as C;
+use pocketmine\item\Item;
 
 /*
 Modified version of MobStacker by UnknownOre


### PR DESCRIPTION
This commit fixes class Item not found error when custom drops is activated.