### PR TITLE
Enable-explosion-drop fixes

### DIFF
--- a/resources/config.yml
+++ b/resources/config.yml
@@ -40,6 +40,10 @@ enable-silk-touch: true
 # use the Silk Touch on Spawners.
 enable-silk-touch-permission: false
 
+## Setting this to true allows spawners to drop when they are exploded
+## (by an entity or tnt).
+enable-explosion-drop: true
+
 # This is the base spawn rate of one Spawner. If this is set to 40, a single unstacked Zombie Spawner
 # spawns a Zombie every 40 seconds. If 2 Spawners are stacked, it spawns one every 20 seconds instead.
 # If you set this value to 20, a single unstacked Zombie Spawner will spawn one Zombie every 20 seconds.

--- a/src/Heisenburger69/BurgerSpawners/Items/SpawnerBlock.php
+++ b/src/Heisenburger69/BurgerSpawners/Items/SpawnerBlock.php
@@ -147,7 +147,7 @@ class SpawnerBlock extends PMSpawner
      */
     public function explode(): bool
     {
-        if (ConfigManager::getToggle("enable-explosion-drop")) {
+        if (!ConfigManager::getToggle("enable-explosion-drop")) {
             return false;
         }
         if(mt_rand(0, 100) > 50) return false;


### PR DESCRIPTION
This PR fixes issues with enabling explosion drop. There was no "enable-explosion-drop" option, so I went and added it, along with some fixes. 