### PR TITLE
Exclude all Entities that are not in the ArrayList.

### DIFF
--- a/resources/config.yml
+++ b/resources/config.yml
@@ -44,6 +44,14 @@ enable-silk-touch-permission: false
 ## (by an entity or tnt).
 enable-explosion-drop: true
 
+## This setting allows you to make explosion drops have a chance.
+## This option will only work if "enable-explosion-drop" is set to true.
+## Default: 50
+## Please also keep in mind - You can't go over 100 in chances, only from 0 to 100.
+## 100 means spawner drops from explosions will always occur.
+## 0 means spawner drops will (either rarely or not at all) happen.
+explosion-drop-chance: 50
+
 # This is the base spawn rate of one Spawner. If this is set to 40, a single unstacked Zombie Spawner
 # spawns a Zombie every 40 seconds. If 2 Spawners are stacked, it spawns one every 20 seconds instead.
 # If you set this value to 20, a single unstacked Zombie Spawner will spawn one Zombie every 20 seconds.

--- a/src/Heisenburger69/BurgerSpawners/EventListener.php
+++ b/src/Heisenburger69/BurgerSpawners/EventListener.php
@@ -84,8 +84,10 @@ class EventListener implements Listener
     {
         $entity = $event->getEntity();
         $this->plugin->getScheduler()->scheduleDelayedTask(new ClosureTask(function (int $currentTick) use ($entity): void {
+              if(!$entity instanceof Living) return;
+            if(!in_array(strtolower($entity->getName()), Utils::getEntityArrayList())) return;
             if (in_array($entity->getId(), $this->plugin->exemptedEntities)) return;
-            if($entity instanceof Living && in_array(Utils::getEntityNameFromID($entity->getId()), $this->plugin->exemptedEntities)) return;
+            if(in_array(Utils::getEntityNameFromID($entity->getId()), $this->plugin->exemptedEntities)) return;
             if($entity->getLevel() === null) return;
             if($entity->getLevel()->isClosed()) return;
             $disabledWorlds = ConfigManager::getArray("mob-stacking-disabled-worlds");

--- a/src/Heisenburger69/BurgerSpawners/Items/SpawnerBlock.php
+++ b/src/Heisenburger69/BurgerSpawners/Items/SpawnerBlock.php
@@ -150,7 +150,7 @@ class SpawnerBlock extends PMSpawner
         if (!ConfigManager::getToggle("enable-explosion-drop")) {
             return false;
         }
-      if (mt_rand(0, 100) <= (int)ConfigManager::getValue("explosion-drop-chance")){
+      if (mt_rand(0, 100) > (int)ConfigManager::getValue("explosion-drop-chance")) return;
         $tile = $this->getLevel()->getTile($this->asVector3());
         if ($tile instanceof MobSpawnerTile) {
             $nbt = new CompoundTag("", [

--- a/src/Heisenburger69/BurgerSpawners/Items/SpawnerBlock.php
+++ b/src/Heisenburger69/BurgerSpawners/Items/SpawnerBlock.php
@@ -150,7 +150,9 @@ class SpawnerBlock extends PMSpawner
         if (!ConfigManager::getToggle("enable-explosion-drop")) {
             return false;
         }
-      if (mt_rand(0, 100) > (int)ConfigManager::getValue("explosion-drop-chance")) return;
+      if (mt_rand(0, 100) > (int)ConfigManager::getValue("explosion-drop-chance")){
+	      return false;
+      }
         $tile = $this->getLevel()->getTile($this->asVector3());
         if ($tile instanceof MobSpawnerTile) {
             $nbt = new CompoundTag("", [

--- a/src/Heisenburger69/BurgerSpawners/Items/SpawnerBlock.php
+++ b/src/Heisenburger69/BurgerSpawners/Items/SpawnerBlock.php
@@ -150,7 +150,7 @@ class SpawnerBlock extends PMSpawner
         if (!ConfigManager::getToggle("enable-explosion-drop")) {
             return false;
         }
-        if(mt_rand(0, 100) > 50) return false;
+      if (mt_rand(0, 100) <= (int)ConfigManager::getValue("explosion-drop-chance")){
         $tile = $this->getLevel()->getTile($this->asVector3());
         if ($tile instanceof MobSpawnerTile) {
             $nbt = new CompoundTag("", [


### PR DESCRIPTION
This PR is based off #97, which fixes the getName() issue. Overall, this PR is to exclude all non-mob entities like armorstands, which cause issues later on.